### PR TITLE
PubSub new/register functions

### DIFF
--- a/protoc-gen-go/micro/micro.go
+++ b/protoc-gen-go/micro/micro.go
@@ -124,7 +124,7 @@ func (g *micro) generatePublisher() {
 
 	// publisher method
 	g.P("func (p *publisher) Publish(ctx ", contextPkg, ".Context, msg interface{}) error {")
-	g.P("return p.c.Publish(ctx, p.c.NewPublication(topic, msg))")
+	g.P("return p.c.Publish(ctx, p.c.NewPublication(p.topic, msg))")
 	g.P("}")
 	g.P()
 

--- a/protoc-gen-go/micro/micro.go
+++ b/protoc-gen-go/micro/micro.go
@@ -75,6 +75,10 @@ func (g *micro) Generate(file *generator.FileDescriptor) {
 	g.P("var _ ", clientPkg, ".Option")
 	g.P("var _ ", serverPkg, ".Option")
 	g.P()
+
+	g.generatePublisher()
+	g.generateSubscriber()
+
 	for i, service := range file.FileDescriptorProto.Service {
 		g.generateService(file, service, i)
 	}
@@ -99,6 +103,52 @@ var reservedClientName = map[string]bool{
 }
 
 func unexport(s string) string { return strings.ToLower(s[:1]) + s[1:] }
+
+// generatePublisher generates the publisher interface
+func (g *micro) generatePublisher() {
+	g.P("// Publisher API")
+	g.P()
+
+	// publisher interface
+	g.P("type Publisher interface {")
+	g.P("Publish(ctx ", contextPkg, ".Context, msg interface{}) error")
+	g.P("}")
+	g.P()
+
+	// publisher type
+	g.P("type publisher struct {")
+	g.P("c ", clientPkg, ".Client")
+	g.P("topic string")
+	g.P("}")
+	g.P()
+
+	// publisher method
+	g.P("func (p *publisher) Publish(ctx ", contextPkg, ".Context, msg interface{}) error {")
+	g.P("return p.c.Publish(ctx, p.c.NewPublication(topic, msg))")
+	g.P("}")
+	g.P()
+
+	// publisher func
+	g.P("func NewPublisher(topic string, c ", clientPkg, ".Client) Publisher {")
+	g.P("if c == nil {")
+	g.P("c = ", clientPkg, ".NewClient()")
+	g.P("}")
+	g.P("return &publisher{c, topic}")
+	g.P("}")
+	g.P()
+}
+
+// generateSubscriber generates the subscriber interface
+func (g *micro) generateSubscriber() {
+	g.P("// Subscriber API")
+	g.P()
+
+	// subscriber func
+	g.P("func RegisterSubscriber(topic string, s ", serverPkg, ".Server, h interface{}) error {")
+	g.P("return s.Subscribe(s.NewSubscriber(topic, h))")
+	g.P("}")
+	g.P()
+}
 
 // generateService generates all the code for the named service.
 func (g *micro) generateService(file *generator.FileDescriptor, service *pb.ServiceDescriptorProto, index int) {


### PR DESCRIPTION
This PR adds some syntactic sugar for a new publisher and registering a subscriber. Yet to be determined whether to merge and also whether to require msg be of proto.Message type and whether handler be an interface with a Handle method.